### PR TITLE
Fix base content deviation for new bamcheck format from samtools 1.3

### DIFF
--- a/bamcheckr/R/bamcheck-read.r
+++ b/bamcheckr/R/bamcheck-read.r
@@ -50,7 +50,7 @@ bamcheck_section_columns <- list(
   SN  = c("variable", "value"),
   COV = c("range.spec", "range.min", "count"),
   FFQ = c("read.cycle", quality_columns),
-  GCC = c("read.cycle", "A.percent", "C.percent", "G.percent", "T.percent"),
+  GCC = c("read.cycle", "A.percent", "C.percent", "G.percent", "T.percent", "N.percent", "O.percent"),
   GCD = c("GC.percent", "unique.sequence.percentiles", "depth.percentile.10th", "depth.percentile.25th", "depth.percentile.50th", "depth.percentile.75th", "depth.percentile.90th"),
   GCF = c("GC.content", "count"),
   GCL = c("GC.content", "count"),

--- a/bamcheckr/R/base-content-deviation.r
+++ b/bamcheckr/R/base-content-deviation.r
@@ -65,7 +65,7 @@ base_content_deviation <- function(bamcheck, baseline_method="mean", runmed_k=25
   #############################################################################
   # "Melt" the data into long (instead of wide) format (filtering out count==0)
   #############################################################################
-  gcc_data_melt <- melt(gcc_data, id.vars="read.cycle", variable.name="base")
+  gcc_data_melt <- melt(gcc_data[,c("read.cycle", "A.percent", "C.percent", "G.percent", "T.percent")], id.vars="read.cycle", variable.name="base")
 
   #############################################################################
   # Calculate A, C, G, T base content percentages over and under baseline


### PR DESCRIPTION
Addition of separate N.percent and 0.percent columns to GCC records in bamcheck format for 1.3
causes bamcheckr to fail. Fix this.